### PR TITLE
Separar lógica de AR que trabaja con `Record<string, Valor>`

### DIFF
--- a/src/ar/modeloSintactico/operadorDeCombinación.ts
+++ b/src/ar/modeloSintactico/operadorDeCombinación.ts
@@ -2,7 +2,7 @@ import {ResultadoConsulta} from "../resultadoConsulta.ts";
 import {ModeloRelacionalMaterializado} from "../../mr/modeloRelacionalMaterializado.ts";
 import {ErrorSemánticoAR} from "../../servicios/errores.ts";
 import {CondiciónAR, ExpresiónAR} from "../modeloSintácticoAR.ts";
-import {Valor} from "../../mr/modeloSintacticoMR.ts";
+import {claveDeTupla, proyectarTupla, TuplaAR} from "../tuplaAR.ts";
 
 export abstract class OperadorDeCombinación extends ExpresiónAR {
     constructor(readonly izq: ExpresiónAR, readonly der: ExpresiónAR) {
@@ -113,35 +113,30 @@ export class JoinNatural extends OperadorDeCombinación {
         }
     }
 
-    private _claveComun(tupla: Record<string, Valor>, comunes: string[]): string {
-        return comunes.map(a => JSON.stringify(tupla[a])).join("|");
-    }
-
     private _combinarConCoincidencias(
-        tuplasDer: ReadonlyArray<Record<string, Valor>>,
-        indiceIzq: Map<string, Record<string, Valor>[]>,
+        tuplasDer: ReadonlyArray<TuplaAR>,
+        indiceIzq: Map<string, TuplaAR[]>,
         comunes: string[],
         noComunesDer: string[],
-    ): Record<string, Valor>[] {
+    ): TuplaAR[] {
         return tuplasDer.flatMap(tuplaDer => {
-            const coincidencias = indiceIzq.get(this._claveComun(tuplaDer, comunes)) ?? [];
+            const coincidencias = indiceIzq.get(claveDeTupla(tuplaDer, comunes)) ?? [];
             return coincidencias.map(tuplaIzq => this._combinarTupla(tuplaIzq, tuplaDer, noComunesDer));
         });
     }
 
     private _indexarPorClaveComun(
-        tuplas: ReadonlyArray<Record<string, Valor>>,
+        tuplas: ReadonlyArray<TuplaAR>,
         comunes: string[],
-    ): Map<string, Record<string, Valor>[]> {
-        return Map.groupBy(tuplas, tupla => this._claveComun(tupla, comunes));
+    ): Map<string, TuplaAR[]> {
+        return Map.groupBy(tuplas, tupla => claveDeTupla(tupla, comunes));
     }
 
     private _combinarTupla(
-        tuplaIzq: Record<string, Valor>,
-        tuplaDer: Record<string, Valor>,
+        tuplaIzq: TuplaAR,
+        tuplaDer: TuplaAR,
         noComunesDer: string[],
-    ): Record<string, Valor> {
-        const atributosNoComunesDer = Object.fromEntries(noComunesDer.map(a => [a, tuplaDer[a]]));
-        return {...tuplaIzq, ...atributosNoComunesDer};
+    ): TuplaAR {
+        return {...tuplaIzq, ...proyectarTupla(tuplaDer, noComunesDer)};
     }
 }

--- a/src/ar/modeloSintactico/operadorDeCombinación.ts
+++ b/src/ar/modeloSintactico/operadorDeCombinación.ts
@@ -2,7 +2,7 @@ import {ResultadoConsulta} from "../resultadoConsulta.ts";
 import {ModeloRelacionalMaterializado} from "../../mr/modeloRelacionalMaterializado.ts";
 import {ErrorSemánticoAR} from "../../servicios/errores.ts";
 import {CondiciónAR, ExpresiónAR} from "../modeloSintácticoAR.ts";
-import {claveDeTupla, proyectarTupla, TuplaAR} from "../tuplaAR.ts";
+import {valoresDeTuplaDesdeEsquema, proyectarTupla, TuplaAR} from "../tuplaAR.ts";
 
 export abstract class OperadorDeCombinación extends ExpresiónAR {
     constructor(readonly izq: ExpresiónAR, readonly der: ExpresiónAR) {
@@ -120,7 +120,7 @@ export class JoinNatural extends OperadorDeCombinación {
         noComunesDer: string[],
     ): TuplaAR[] {
         return tuplasDer.flatMap(tuplaDer => {
-            const coincidencias = indiceIzq.get(claveDeTupla(tuplaDer, comunes)) ?? [];
+            const coincidencias = indiceIzq.get(valoresDeTuplaDesdeEsquema(tuplaDer, comunes)) ?? [];
             return coincidencias.map(tuplaIzq => this._combinarTupla(tuplaIzq, tuplaDer, noComunesDer));
         });
     }
@@ -129,7 +129,7 @@ export class JoinNatural extends OperadorDeCombinación {
         tuplas: ReadonlyArray<TuplaAR>,
         comunes: string[],
     ): Map<string, TuplaAR[]> {
-        return Map.groupBy(tuplas, tupla => claveDeTupla(tupla, comunes));
+        return Map.groupBy(tuplas, tupla => valoresDeTuplaDesdeEsquema(tupla, comunes));
     }
 
     private _combinarTupla(

--- a/src/ar/modeloSintactico/operadorDeConjuntos.ts
+++ b/src/ar/modeloSintactico/operadorDeConjuntos.ts
@@ -1,8 +1,8 @@
 import {ResultadoConsulta} from "../resultadoConsulta.ts";
-import {Valor} from "../../mr/modeloSintacticoMR.ts";
 import {ModeloRelacionalMaterializado} from "../../mr/modeloRelacionalMaterializado.ts";
 import {ErrorSemánticoAR} from "../../servicios/errores.ts";
 import {ExpresiónAR} from "../modeloSintácticoAR.ts";
+import {mismaTupla, TuplaAR} from "../tuplaAR.ts";
 
 export abstract class OperadorDeConjuntos extends ExpresiónAR {
     constructor(readonly izq: ExpresiónAR, readonly der: ExpresiónAR) {
@@ -44,7 +44,7 @@ export abstract class OperadorDeConjuntos extends ExpresiónAR {
         return operandoIzquierdo.atributos;
     }
 
-    protected _renombrarConjunto(tuplas: ReadonlyArray<Record<string, Valor>>, esquemaActual: readonly string[], esquemaRenombrado: readonly string[]): Record<string, Valor>[] {
+    protected _renombrarConjunto(tuplas: ReadonlyArray<TuplaAR>, esquemaActual: readonly string[], esquemaRenombrado: readonly string[]): TuplaAR[] {
         return tuplas.map(tupla =>
             Object.fromEntries(
                 esquemaRenombrado.map((nombre, i) => [nombre, tupla[esquemaActual[i]]]),
@@ -87,8 +87,4 @@ export class Resta extends OperadorDeConjuntos {
         );
         return new ResultadoConsulta("", [...operandoIzquierdo.atributos], soloEnIzq);
     }
-}
-
-function mismaTupla(a: Record<string, Valor>, b: Record<string, Valor>, atributos: readonly string[]): boolean {
-    return atributos.every(attr => a[attr] === b[attr]);
 }

--- a/src/ar/modeloSintactico/operadorDeDivisión.ts
+++ b/src/ar/modeloSintactico/operadorDeDivisión.ts
@@ -1,7 +1,7 @@
 import {ResultadoConsulta} from "../resultadoConsulta.ts";
 import {ErrorSemánticoAR} from "../../servicios/errores.ts";
 import {OperadorDeConjuntos} from "./operadorDeConjuntos.ts";
-import {claveDeTupla, proyectarTupla, TuplaAR} from "../tuplaAR.ts";
+import {valoresDeTuplaDesdeEsquema, proyectarTupla, TuplaAR} from "../tuplaAR.ts";
 
 type GrupoDelDividendo = {
     candidata: TuplaAR;
@@ -73,7 +73,7 @@ export class División extends OperadorDeConjuntos {
         tuplas: ReadonlyArray<TuplaAR>,
         esquemaResultado: readonly string[],
     ): Map<string, TuplaAR[]> {
-        return Map.groupBy(tuplas, tupla => claveDeTupla(tupla, esquemaResultado));
+        return Map.groupBy(tuplas, tupla => valoresDeTuplaDesdeEsquema(tupla, esquemaResultado));
     }
 
     private _crearGrupoDelDividendo(
@@ -85,7 +85,7 @@ export class División extends OperadorDeConjuntos {
             candidata: proyectarTupla(tuplasDelGrupo[0], esquemaResultado),
             valoresDelDivisorQueCubre: new Set(
                 tuplasDelGrupo.map(tupla =>
-                    claveDeTupla(tupla, esquemaImplicadoEnLaDivisiónDelDividendo)
+                    valoresDeTuplaDesdeEsquema(tupla, esquemaImplicadoEnLaDivisiónDelDividendo)
                 ),
             )
         };
@@ -115,7 +115,7 @@ export class División extends OperadorDeConjuntos {
         return tuplasDelDivisor.every(
             tuplaDivisor =>
                 grupo.valoresDelDivisorQueCubre.has(
-                    claveDeTupla(
+                    valoresDeTuplaDesdeEsquema(
                         tuplaDivisor,
                         esquemaImplicadoEnLaDivisiónDelDividendo
                     )

--- a/src/ar/modeloSintactico/operadorDeDivisión.ts
+++ b/src/ar/modeloSintactico/operadorDeDivisión.ts
@@ -1,10 +1,10 @@
 import {ResultadoConsulta} from "../resultadoConsulta.ts";
-import {Valor} from "../../mr/modeloSintacticoMR.ts";
 import {ErrorSemánticoAR} from "../../servicios/errores.ts";
 import {OperadorDeConjuntos} from "./operadorDeConjuntos.ts";
+import {claveDeTupla, proyectarTupla, TuplaAR} from "../tuplaAR.ts";
 
 type GrupoDelDividendo = {
-    candidata: Record<string, Valor>;
+    candidata: TuplaAR;
     valoresDelDivisorQueCubre: Set<string>;
 };
 
@@ -42,11 +42,11 @@ export class División extends OperadorDeConjuntos {
     }
 
     private _tuplasQueCubrenTodoElDivisor(
-        tuplasDelDividendo: ReadonlyArray<Record<string, Valor>>,
-        tuplasDelDivisor: ReadonlyArray<Record<string, Valor>>,
+        tuplasDelDividendo: ReadonlyArray<TuplaAR>,
+        tuplasDelDivisor: ReadonlyArray<TuplaAR>,
         esquemaDelResultado: readonly string[],
         esquemaImplicadoEnLaDivisiónDelDividendo: readonly string[]
-    ): Record<string, Valor>[] {
+    ): TuplaAR[] {
         return this._filtrarCandidatasQueCubrenElDivisor(
             this._agruparDividendo(
                 tuplasDelDividendo, esquemaDelResultado, esquemaImplicadoEnLaDivisiónDelDividendo,
@@ -57,7 +57,7 @@ export class División extends OperadorDeConjuntos {
     }
 
     private _agruparDividendo(
-        tuplas: ReadonlyArray<Record<string, Valor>>,
+        tuplas: ReadonlyArray<TuplaAR>,
         esquemaResultado: readonly string[],
         esquemaImplicadoEnLaDivisiónDelDividendo: readonly string[]
     ): GrupoDelDividendo[] {
@@ -70,22 +70,22 @@ export class División extends OperadorDeConjuntos {
     }
 
     private _agruparPorClaveDelResultado(
-        tuplas: ReadonlyArray<Record<string, Valor>>,
+        tuplas: ReadonlyArray<TuplaAR>,
         esquemaResultado: readonly string[],
-    ): Map<string, Record<string, Valor>[]> {
-        return Map.groupBy(tuplas, tupla => this._clave(tupla, esquemaResultado));
+    ): Map<string, TuplaAR[]> {
+        return Map.groupBy(tuplas, tupla => claveDeTupla(tupla, esquemaResultado));
     }
 
     private _crearGrupoDelDividendo(
-        tuplasDelGrupo: Record<string, Valor>[],
+        tuplasDelGrupo: TuplaAR[],
         esquemaResultado: readonly string[],
         esquemaImplicadoEnLaDivisiónDelDividendo: readonly string[],
     ): GrupoDelDividendo {
         return {
-            candidata: this._proyectarTupla(tuplasDelGrupo[0], esquemaResultado),
+            candidata: proyectarTupla(tuplasDelGrupo[0], esquemaResultado),
             valoresDelDivisorQueCubre: new Set(
                 tuplasDelGrupo.map(tupla =>
-                    this._clave(tupla, esquemaImplicadoEnLaDivisiónDelDividendo)
+                    claveDeTupla(tupla, esquemaImplicadoEnLaDivisiónDelDividendo)
                 ),
             )
         };
@@ -93,9 +93,9 @@ export class División extends OperadorDeConjuntos {
 
     private _filtrarCandidatasQueCubrenElDivisor(
         gruposDelDividendo: GrupoDelDividendo[],
-        tuplasDelDivisor: ReadonlyArray<Record<string, Valor>>,
+        tuplasDelDivisor: ReadonlyArray<TuplaAR>,
         esquemaImplicadoEnLaDivisiónDelDividendo: readonly string[],
-    ): Record<string, Valor>[] {
+    ): TuplaAR[] {
         return gruposDelDividendo
             .filter(grupo =>
                 this._grupoCubreTodoElDivisor(
@@ -109,25 +109,17 @@ export class División extends OperadorDeConjuntos {
 
     private _grupoCubreTodoElDivisor(
         grupo: GrupoDelDividendo,
-        tuplasDelDivisor: ReadonlyArray<Record<string, Valor>>,
+        tuplasDelDivisor: ReadonlyArray<TuplaAR>,
         esquemaImplicadoEnLaDivisiónDelDividendo: readonly string[],
     ): boolean {
         return tuplasDelDivisor.every(
             tuplaDivisor =>
                 grupo.valoresDelDivisorQueCubre.has(
-                    this._clave(
+                    claveDeTupla(
                         tuplaDivisor,
                         esquemaImplicadoEnLaDivisiónDelDividendo
                     )
                 )
         );
-    }
-
-    private _proyectarTupla(tupla: Record<string, Valor>, esquema: readonly string[]): Record<string, Valor> {
-        return Object.fromEntries(esquema.map(atributo => [atributo, tupla[atributo]]));
-    }
-
-    private _clave(tupla: Record<string, Valor>, esquema: readonly string[]): string {
-        return esquema.map(columna => tupla[columna].toString()).join("|");
     }
 }

--- a/src/ar/modeloSintácticoAR.ts
+++ b/src/ar/modeloSintácticoAR.ts
@@ -1,6 +1,7 @@
 import {ModeloRelacionalMaterializado} from "../mr/modeloRelacionalMaterializado.ts";
 import {ResultadoConsulta} from "./resultadoConsulta.ts";
 import {Valor} from "../mr/modeloSintacticoMR.ts";
+import {proyectarTupla, TuplaAR} from "./tuplaAR.ts";
 import {ErrorSemánticoAR} from "../servicios/errores.ts";
 
 export abstract class ExpresiónAR {
@@ -22,23 +23,23 @@ export class NombreDeRelación extends ExpresiónAR {
 }
 
 export abstract class Operando {
-    abstract resolverCon(tupla: Record<string, Valor>): Valor;
+    abstract resolverCon(tupla: TuplaAR): Valor;
     nombresDeAtributos(): string[] { return []; }
 }
 
 export class NombreAtributo extends Operando {
     constructor(readonly nombre: string) { super(); }
-    resolverCon(tupla: Record<string, Valor>): Valor { return tupla[this.nombre]; }
+    resolverCon(tupla: TuplaAR): Valor { return tupla[this.nombre]; }
     nombresDeAtributos(): string[] { return [this.nombre]; }
 }
 
 export class Literal extends Operando {
     constructor(readonly valor: Valor) { super(); }
-    resolverCon(_tupla: Record<string, Valor>): Valor { return this.valor; }
+    resolverCon(_tupla: TuplaAR): Valor { return this.valor; }
 }
 
 export abstract class CondiciónAR {
-    abstract evaluarCon(tupla: Record<string, Valor>): boolean;
+    abstract evaluarCon(tupla: TuplaAR): boolean;
     abstract atributos(): string[];
 }
 
@@ -49,7 +50,7 @@ export class ComparaciónPrimitiva extends CondiciónAR {
         readonly der: Operando,
     ) { super(); }
 
-    evaluarCon(tupla: Record<string, Valor>): boolean {
+    evaluarCon(tupla: TuplaAR): boolean {
         const a = this.izq.resolverCon(tupla);
         const b = this.der.resolverCon(tupla);
         switch (this.op) {
@@ -70,7 +71,7 @@ export class ComparaciónPrimitiva extends CondiciónAR {
 
 export class CondiciónAtómica extends CondiciónAR {
     constructor(readonly operando: Operando) { super(); }
-    evaluarCon(tupla: Record<string, Valor>): boolean {
+    evaluarCon(tupla: TuplaAR): boolean {
         const val = this.operando.resolverCon(tupla);
         if (typeof val === "boolean") {
             return val;
@@ -85,7 +86,7 @@ export class CondiciónAtómica extends CondiciónAR {
 
 export class Conjunción extends CondiciónAR {
     constructor(readonly izq: CondiciónAR, readonly der: CondiciónAR) { super(); }
-    evaluarCon(tupla: Record<string, Valor>): boolean {
+    evaluarCon(tupla: TuplaAR): boolean {
         return this.izq.evaluarCon(tupla) && this.der.evaluarCon(tupla);
     }
     atributos(): string[] {
@@ -95,7 +96,7 @@ export class Conjunción extends CondiciónAR {
 
 export class Disyunción extends CondiciónAR {
     constructor(readonly izq: CondiciónAR, readonly der: CondiciónAR) { super(); }
-    evaluarCon(tupla: Record<string, Valor>): boolean {
+    evaluarCon(tupla: TuplaAR): boolean {
         return this.izq.evaluarCon(tupla) || this.der.evaluarCon(tupla);
     }
     atributos(): string[] {
@@ -132,13 +133,7 @@ export class ExpresiónProyección extends ExpresiónAR {
             }
         });
 
-        const tuplasProyectadas = resultado.tuplas.map(tupla => {
-            const proyectada: Record<string, Valor> = {};
-            this.atributos.forEach(attr => {
-                proyectada[attr] = tupla[attr];
-            });
-            return proyectada;
-        });
+        const tuplasProyectadas = resultado.tuplas.map(tupla => proyectarTupla(tupla, this.atributos));
 
         return new ResultadoConsulta("", [...this.atributos], tuplasProyectadas);
     }

--- a/src/ar/resultadoConsulta.ts
+++ b/src/ar/resultadoConsulta.ts
@@ -1,4 +1,4 @@
-import {claveDeTupla, TuplaAR} from "./tuplaAR.ts";
+import {valoresDeTuplaDesdeEsquema, TuplaAR} from "./tuplaAR.ts";
 
 export class ResultadoConsulta {
     readonly nombre: string;
@@ -8,7 +8,7 @@ export class ResultadoConsulta {
     constructor(nombre: string, atributos: string[], tuplas: Array<TuplaAR>) {
         const visto = new Set<string>();
         const tuplasSinRepetidos = tuplas.filter(t => {
-            const clave = claveDeTupla(t, atributos);
+            const clave = valoresDeTuplaDesdeEsquema(t, atributos);
             if (visto.has(clave)) return false;
             visto.add(clave);
             return true;

--- a/src/ar/resultadoConsulta.ts
+++ b/src/ar/resultadoConsulta.ts
@@ -1,14 +1,14 @@
-import {Valor} from "../mr/modeloSintacticoMR.ts";
+import {claveDeTupla, TuplaAR} from "./tuplaAR.ts";
 
 export class ResultadoConsulta {
     readonly nombre: string;
     readonly atributos: ReadonlyArray<string>;
-    private readonly _tuplas: ReadonlyArray<Record<string, Valor>>;
+    private readonly _tuplas: ReadonlyArray<TuplaAR>;
 
-    constructor(nombre: string, atributos: string[], tuplas: Array<Record<string, Valor>>) {
+    constructor(nombre: string, atributos: string[], tuplas: Array<TuplaAR>) {
         const visto = new Set<string>();
         const tuplasSinRepetidos = tuplas.filter(t => {
-            const clave = JSON.stringify(atributos.map(a => t[a]));
+            const clave = claveDeTupla(t, atributos);
             if (visto.has(clave)) return false;
             visto.add(clave);
             return true;
@@ -18,11 +18,11 @@ export class ResultadoConsulta {
         this._tuplas = tuplasSinRepetidos;
     }
 
-    get tuplas(): ReadonlyArray<Record<string, Valor>> {
+    get tuplas(): ReadonlyArray<TuplaAR> {
         return this._tuplas;
     }
 
-    filtrar(predicado: (t: Record<string, Valor>) => boolean): ResultadoConsulta {
+    filtrar(predicado: (t: TuplaAR) => boolean): ResultadoConsulta {
         return new ResultadoConsulta("", [...this.atributos], this._tuplas.filter(predicado));
     }
 }

--- a/src/ar/tuplaAR.ts
+++ b/src/ar/tuplaAR.ts
@@ -2,7 +2,7 @@ import {Valor} from "../mr/modeloSintacticoMR.ts";
 
 export type TuplaAR = Record<string, Valor>;
 
-export function claveDeTupla(tupla: TuplaAR, esquema: readonly string[]): string {
+export function valoresDeTuplaDesdeEsquema(tupla: TuplaAR, esquema: readonly string[]): string {
     return JSON.stringify(esquema.map(a => tupla[a]));
 }
 

--- a/src/ar/tuplaAR.ts
+++ b/src/ar/tuplaAR.ts
@@ -1,0 +1,15 @@
+import {Valor} from "../mr/modeloSintacticoMR.ts";
+
+export type TuplaAR = Record<string, Valor>;
+
+export function claveDeTupla(tupla: TuplaAR, esquema: readonly string[]): string {
+    return JSON.stringify(esquema.map(a => tupla[a]));
+}
+
+export function proyectarTupla(tupla: TuplaAR, esquema: readonly string[]): TuplaAR {
+    return Object.fromEntries(esquema.map(a => [a, tupla[a]]));
+}
+
+export function mismaTupla(a: TuplaAR, b: TuplaAR, atributos: readonly string[]): boolean {
+    return atributos.every(attr => a[attr] === b[attr]);
+}

--- a/test/ar/helpers.ts
+++ b/test/ar/helpers.ts
@@ -4,8 +4,8 @@ import {TokenizadorAR} from "../../src/ar/tokenizadorAR.ts";
 import {TipoTokenAR, TokenAR} from "../../src/tipos/tipos.ts";
 import {ErrorSintácticoAR} from "../../src/servicios/errores.ts";
 import {ResultadoConsulta} from "../../src/ar/resultadoConsulta.ts";
-import {Valor} from "../../src/mr/modeloSintacticoMR.ts";
 import {ExpresiónAR} from "../../src/ar/modeloSintácticoAR.ts";
+import {TuplaAR} from "../../src/ar/tuplaAR.ts";
 
 export function tokenizar(texto: string): TokenAR[] {
     return new TokenizadorAR().ejecutarseCon(texto);
@@ -32,7 +32,7 @@ export function esperarAnálisisSintácticoAR(
 
 export function esperarResultadoConsulta(
     resultado: ResultadoConsulta,
-    esperado: ReadonlyArray<Record<string, Valor>>,
+    esperado: ReadonlyArray<TuplaAR>,
 ): void {
     expect(resultado.tuplas).toHaveLength(esperado.length);
     esperado.forEach(tuplaEsperada => {


### PR DESCRIPTION
Extraje un tipo `TuplaAR = Record<string, Valor>`, y puse toda la lógica en el archivo `src/ar/tuplaAR.ts` (revisaría ese archivo primero). 
Le puse de nombre `TuplaAR` en lugar de `Tupla` porque ya existe una clase `Tupla` (en MR). No estoy del todo convencido de que haya una clase `Tupla` en MR y otro tipo `TuplaAR` en AR, pero decidir si esa unificación es deseable o no queda fuera del alcance de este PR.

:memo: Tambien, hay algunos nombres de los que no estoy del todo seguro (ej. `claveDeTupla`), pero que los dejé como lo más cercano de lo que estaban (tampoco estoy seguro de que haya que cambiarlos, lo comento nada más por contexto).

:eye: Este cambio incluye además la unificación de parte de la lógica que usaba `JSON.stringify`/`toString`, que estaba (casi) duplicada y era propensa a error (ej. en `División` podía fallar si había nombres que contenían el caracter '|', etc.). Quizás eso es lo menos "mecánico" para revisar.